### PR TITLE
Csgmdl5

### DIFF
--- a/src/mesh_data.rs
+++ b/src/mesh_data.rs
@@ -246,10 +246,10 @@ pub struct MeshData5{
 	pub pos:Vec<[f32;3]>,
 
 	// probably has to do with normals
-	pub _unknown1_count:u16,//208
-	pub _unknown1_len:u32,//208*6 = 1248
-	#[br(count=_unknown1_count)]
-	pub _unknown1_list:Vec<[u8;6]>,// 1248 bytes long
+	pub norm_count:u16,//208
+	pub norm_len:u32,//208*6 = 1248
+	#[br(count=norm_count)]
+	pub norm_list:Vec<[i16;3]>,// 1248 bytes long
 
 	pub color_count:u16,//208
 	#[br(count=color_count)]

--- a/src/mesh_data.rs
+++ b/src/mesh_data.rs
@@ -224,6 +224,65 @@ pub struct CSGMDL5{
 	// pub rest:Vec<u8>,
 }
 #[binrw::binrw]
+#[brw(little,repr=u8)]
+#[derive(Debug,Clone)]
+// Why does this differ from Roblox's own standard?
+pub enum NormalId5{
+	Right=1,
+	Top=2,
+	Back=3,
+	Left=4,
+	Bottom=5,
+	Front=6,
+}
+#[binrw::binrw]
+#[brw(little)]
+#[derive(Debug,Clone)]
+pub struct MeshData5{
+	// #[brw(magic=b"CSGMDL\x05\0\0\0")] but obfuscated
+	#[brw(magic=b"\x15\x7d\x29\x15\x75\x6c\x35\x04\x34\x69")]
+	pub pos_count:u16,//208
+	#[br(count=pos_count)]
+	pub pos:Vec<[f32;3]>,
+
+	// probably has to do with normals
+	pub _unknown1_count:u16,//208
+	pub _unknown1_len:u32,//208*6 = 1248
+	#[br(count=_unknown1_count)]
+	pub _unknown1_list:Vec<[u8;6]>,// 1248 bytes long
+
+	pub color_count:u16,//208
+	#[br(count=color_count)]
+	pub colors:Vec<[u8;4]>,
+
+	pub normal_id_count:u16,//208
+	#[br(count=normal_id_count)]
+	pub normal_id_list:Vec<NormalId5>,
+
+	pub tex_count:u16,//208
+	#[br(count=tex_count)]
+	pub tex:Vec<[f32;2]>,
+
+	// probably has to do with tangents
+	pub _unknown4_count:u16,//208
+	pub _unknown4_len:u32,//208*6 = 1248
+	#[br(count=_unknown4_count)]
+	pub _unknown4_list:Vec<[u8;6]>,// 1248 bytes long
+
+	// triangle strip? u8 because each one is an increment on previous ids?
+	pub _unknown5_count1:u32,//984
+	pub _unknown5_count2:u32,//986
+	#[br(count=_unknown5_count2)]
+	pub _unknown5_list:Vec<u8>,
+
+	pub _unknown6_count:u8,//2-3
+	#[br(count=_unknown6_count)]
+	// the numbers in this list seem to match various list lengths
+	pub _unknown6_list:Vec<u32>,
+	// #[br(parse_with=binrw::helpers::until_eof)]
+	// pub rest:Vec<u8>,
+}
+#[binrw::binrw]
 #[brw(little)]
 #[derive(Debug,Clone)]
 pub enum CSGMDL{

--- a/src/mesh_data.rs
+++ b/src/mesh_data.rs
@@ -178,67 +178,8 @@ pub enum NormalId5{
 }
 #[binrw::binrw]
 #[brw(little)]
-#[derive(Debug,Clone)]
-pub struct CSGMDL5{
-	// #[brw(magic=b"CSGMDL\x05\0\0\0")] but obfuscated
-	#[brw(magic=b"\x15\x7d\x29\x15\x75\x6c\x35\x04\x34\x69")]
-	pub pos_count:u16,//208
-	#[br(count=pos_count)]
-	pub pos:Vec<[f32;3]>,
-
-	// probably has to do with normals
-	pub norm_count:u16,//208
-	pub norm_len:u32,//208*6 = 1248
-	#[br(count=norm_count)]
-	pub norm_list:Vec<[i16;3]>,// 1248 bytes long
-
-	pub color_count:u16,//208
-	#[br(count=color_count)]
-	pub colors:Vec<[u8;4]>,
-
-	pub normal_id_count:u16,//208
-	#[br(count=normal_id_count)]
-	pub normal_id_list:Vec<NormalId5>,
-
-	pub tex_count:u16,//208
-	#[br(count=tex_count)]
-	pub tex:Vec<[f32;2]>,
-
-	// probably has to do with tangents
-	pub _unknown4_count:u16,//208
-	pub _unknown4_len:u32,//208*6 = 1248
-	#[br(count=_unknown4_count)]
-	pub _unknown4_list:Vec<[u8;6]>,// 1248 bytes long
-
-	// triangle strip? u8 because each one is an increment on previous ids?
-	pub _unknown5_count1:u32,//984
-	pub _unknown5_count2:u32,//986
-	#[br(count=_unknown5_count2)]
-	pub _unknown5_list:Vec<u8>,
-
-	pub _unknown6_count:u8,//2-3
-	#[br(count=_unknown6_count)]
-	// the numbers in this list seem to match various list lengths
-	pub _unknown6_list:Vec<u32>,
-	// #[br(parse_with=binrw::helpers::until_eof)]
-	// pub rest:Vec<u8>,
-}
-#[binrw::binrw]
-#[brw(little,repr=u8)]
-#[derive(Debug,Clone)]
-// Why does this differ from Roblox's own standard?
-pub enum NormalId5{
-	Right=1,
-	Top=2,
-	Back=3,
-	Left=4,
-	Bottom=5,
-	Front=6,
-}
-#[binrw::binrw]
-#[brw(little)]
 #[derive(Debug, Clone)]
-pub struct MeshData5 {
+pub struct CSGMDL5 {
 	#[brw(magic = b"\x15\x7d\x29\x15\x75\x6c\x35\x04\x34\x69")]
 
 	vertex_count: u16,

--- a/src/test/mesh_data.rs
+++ b/src/test/mesh_data.rs
@@ -40,16 +40,17 @@ fn dbg_mesh_data(mesh_data:MeshData,expected_version:&str){
 		},
 		MeshData::CSGMDL(CSGMDL::V5(mesh_data5))=>{
 			println!("===V5===");
-			println!("pos_count={}",mesh_data5.pos_count);
-			println!("norm_count={}",mesh_data5.norm_count);
-			println!("norm_len={}",mesh_data5.norm_len);
-			for (i,thing) in mesh_data5.norm_list.into_iter().enumerate(){
-				print!("u1 row={i:03} bin=");
-				for byte in thing{
-					print!("{byte:016b} ");
-				}
-				println!("list={thing:?}");
-			}
+			println!("{:?}", mesh_data5);
+			// println!("pos_count={}",mesh_data5.pos_count);
+			// println!("norm_count={}",mesh_data5.norm_count);
+			// println!("norm_len={}",mesh_data5.norm_len);
+			// for (i,thing) in mesh_data5.norm_list.into_iter().enumerate(){
+			// 	print!("u1 row={i:03} bin=");
+			// 	for byte in thing{
+			// 		print!("{byte:016b} ");
+			// 	}
+			// 	println!("list={thing:?}");
+			// }
 			// println!("color_count={}",mesh_data5.color_count);
 			// println!("normal_id_count={}",mesh_data5.normal_id_count);
 			// println!("tex_count={}",mesh_data5.tex_count);


### PR DESCRIPTION
Reversed based off of Roblox's parser.

Not fully happy with including the parse_with helpers in this file, at least not where they're at. There may be a cleaner way to do what I want using binrw, or just breaking it down further into separate structs.