### PR TITLE
Unify Mesh

### DIFF
--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -47,25 +47,6 @@ pub enum Mesh {
 	//Version7(Mesh7),
 }
 
-pub fn fix_vertex2_tangents(vertices: &mut [Vertex2]) {
-	const DEFAULT_VERTEX_TANGENT: [i8; 4] = [0, 0, -128, 127];
-	for vertex in vertices {
-		match vertex.tangent {
-			[-128, -128, -128, -128] => vertex.tangent = DEFAULT_VERTEX_TANGENT,
-			_ => (),
-		}
-	}
-}
-
 pub fn read_versioned<R: BinReaderExt>(mut read: R) -> Result<Mesh, Error> {
-	let mut mesh = read.read_le()?;
-	match &mut mesh {
-		#[cfg(feature = "mesh-v1")]
-		Mesh::V1(_) => (),
-		Mesh::V2(mesh) => fix_vertex2_tangents(&mut mesh.vertices),
-		Mesh::V3(mesh) => fix_vertex2_tangents(&mut mesh.vertices),
-		Mesh::V4(mesh) => fix_vertex2_tangents(&mut mesh.vertices),
-		Mesh::V5(mesh) => fix_vertex2_tangents(&mut mesh.vertices),
-	}
-	Ok(mesh)
+	read.read_le()
 }

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -44,6 +44,7 @@ pub fn fix_vertex2_tangents(vertices: &mut [Vertex2]) {
 pub fn read_versioned<R: BinReaderExt>(mut read: R) -> Result<Mesh, Error> {
 	let mut mesh = read.read_le()?;
 	match &mut mesh {
+		#[cfg(feature = "mesh-v1")]
 		Mesh::V1(_) => (),
 		Mesh::V2(mesh) => fix_vertex2_tangents(&mut mesh.vertices),
 		Mesh::V3(mesh) => fix_vertex2_tangents(&mut mesh.vertices),

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -13,27 +13,14 @@ pub use v4::*;
 mod v5;
 pub use v5::*;
 
-use std::io::{Read, Seek};
+use binrw::BinReaderExt;
 
 pub const DEFAULT_VERTEX_TANGENT: [i8; 4] = [0, 0, -128, 127];
 
-#[derive(Debug)]
-pub enum Error {
-	Io(std::io::Error),
-	UnknownVersion([u8; 12]),
-	//1.00
-	#[cfg(feature = "mesh-v1")]
-	V1(Error1),
-	//2.00+
-	BinRead(binrw::Error),
-}
-impl std::fmt::Display for Error {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{self:?}")
-	}
-}
-impl std::error::Error for Error {}
+pub type Error = binrw::Error;
 
+#[binrw::binread]
+#[br(little)]
 #[derive(Debug, Clone)]
 pub enum Mesh {
 	#[cfg(feature = "mesh-v1")]
@@ -46,25 +33,6 @@ pub enum Mesh {
 	//Version7(Mesh7),
 }
 
-pub fn read_versioned<R: Read + Seek>(mut read: R) -> Result<Mesh, Error> {
-	let mut peek = [0u8; 12];
-	read.read_exact(&mut peek).map_err(Error::Io)?;
-	read.seek(std::io::SeekFrom::Start(0)).map_err(Error::Io)?;
-	match &peek {
-		#[cfg(feature = "mesh-v1")]
-		b"version 1.00" => Ok(Mesh::V1(
-			read_100(binrw::io::BufReader::new(read)).map_err(Error::V1)?,
-		)),
-		#[cfg(feature = "mesh-v1")]
-		b"version 1.01" => Ok(Mesh::V1(
-			read_101(binrw::io::BufReader::new(read)).map_err(Error::V1)?,
-		)),
-		b"version 2.00" => Ok(Mesh::V2(read_200(read).map_err(Error::BinRead)?)),
-		b"version 3.00" | b"version 3.01" => Ok(Mesh::V3(read_300(read).map_err(Error::BinRead)?)),
-		b"version 4.00" | b"version 4.01" => Ok(Mesh::V4(read_400(read).map_err(Error::BinRead)?)),
-		b"version 5.00" => Ok(Mesh::V5(read_500(read).map_err(Error::BinRead)?)),
-		//b"version 6.00"=>Ok(VersionedMesh::Version6(read_600(read)?)),
-		//b"version 7.00"=>Ok(VersionedMesh::Version7(read_700(read)?)),
-		&other => Err(Error::UnknownVersion(other)),
-	}
+pub fn read_versioned<R: BinReaderExt>(mut read: R) -> Result<Mesh, Error> {
+	read.read_le()
 }

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -17,12 +17,28 @@ use binrw::BinReaderExt;
 
 pub type Error = binrw::Error;
 
+#[cfg(feature = "mesh-v1")]
 #[binrw::binread]
 #[br(little)]
 #[derive(Debug, Clone)]
 pub enum Mesh {
-	#[cfg(feature = "mesh-v1")]
+	// TODO: use feature-gated enum variant when this issue is fixed
+	// https://github.com/jam1garner/binrw/issues/360
+	// #[cfg(feature = "mesh-v1")]
 	V1(Mesh1),
+	V2(Mesh2),
+	V3(Mesh3),
+	V4(Mesh4),
+	V5(Mesh5),
+	//Version6(Mesh6),
+	//Version7(Mesh7),
+}
+
+#[cfg(not(feature = "mesh-v1"))]
+#[binrw::binread]
+#[br(little)]
+#[derive(Debug, Clone)]
+pub enum Mesh {
 	V2(Mesh2),
 	V3(Mesh3),
 	V4(Mesh4),

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -15,8 +15,6 @@ pub use v5::*;
 
 use binrw::BinReaderExt;
 
-pub const DEFAULT_VERTEX_TANGENT: [i8; 4] = [0, 0, -128, 127];
-
 pub type Error = binrw::Error;
 
 #[binrw::binread]

--- a/src/mesh/mod.rs
+++ b/src/mesh/mod.rs
@@ -31,6 +31,24 @@ pub enum Mesh {
 	//Version7(Mesh7),
 }
 
+pub fn fix_vertex2_tangents(vertices: &mut [Vertex2]) {
+	const DEFAULT_VERTEX_TANGENT: [i8; 4] = [0, 0, -128, 127];
+	for vertex in vertices {
+		match vertex.tangent {
+			[-128, -128, -128, -128] => vertex.tangent = DEFAULT_VERTEX_TANGENT,
+			_ => (),
+		}
+	}
+}
+
 pub fn read_versioned<R: BinReaderExt>(mut read: R) -> Result<Mesh, Error> {
-	read.read_le()
+	let mut mesh = read.read_le()?;
+	match &mut mesh {
+		Mesh::V1(_) => (),
+		Mesh::V2(mesh) => fix_vertex2_tangents(&mut mesh.vertices),
+		Mesh::V3(mesh) => fix_vertex2_tangents(&mut mesh.vertices),
+		Mesh::V4(mesh) => fix_vertex2_tangents(&mut mesh.vertices),
+		Mesh::V5(mesh) => fix_vertex2_tangents(&mut mesh.vertices),
+	}
+	Ok(mesh)
 }

--- a/src/mesh/v1.rs
+++ b/src/mesh/v1.rs
@@ -1,8 +1,9 @@
 use std::io::BufRead;
 
+use binrw::BinReaderExt;
+
 #[derive(Debug)]
 pub enum Error1 {
-	Io(std::io::Error),
 	Header,
 	UnexpectedEof,
 	ParseIntError(std::num::ParseIntError),
@@ -16,6 +17,27 @@ impl std::fmt::Display for Error1 {
 }
 impl std::error::Error for Error1 {}
 
+enum InnerError {
+	Io(std::io::Error),
+	Other(Error1),
+}
+impl From<Error1> for InnerError {
+	fn from(value: Error1) -> Self {
+		Self::Other(value)
+	}
+}
+impl From<InnerError> for binrw::Error {
+	fn from(value: InnerError) -> Self {
+		match value {
+			InnerError::Io(error) => Self::Io(error),
+			InnerError::Other(error1) => Self::Custom {
+				pos: 0,
+				err: Box::new(error1),
+			},
+		}
+	}
+}
+
 struct LineMachine<R: BufRead> {
 	lines: std::io::Lines<R>,
 }
@@ -25,53 +47,59 @@ impl<R: BufRead> LineMachine<R> {
 			lines: read.lines(),
 		}
 	}
-	fn read_line(&mut self) -> Result<String, Error1> {
+	fn read_line(&mut self) -> Result<String, InnerError> {
 		Ok(self
 			.lines
 			.next()
-			.ok_or(Error1::UnexpectedEof)?
-			.map_err(Error1::Io)?)
+			.ok_or(InnerError::Other(Error1::UnexpectedEof))?
+			.map_err(InnerError::Io)?)
 	}
 }
 
+#[binrw::binrw]
+#[brw(little)]
 #[derive(Debug, Clone)]
 pub enum Revision1 {
+	#[brw(magic = b"version 1.00")]
 	Version100,
+	#[brw(magic = b"version 1.01")]
 	Version101,
 }
+
 #[derive(Debug, Clone)]
 pub struct Vertex1 {
 	pub pos: [f32; 3],
 	pub norm: [f32; 3],
 	pub tex: [f32; 3],
 }
+
 #[derive(Debug, Clone)]
 pub struct Header1 {
 	pub revision: Revision1,
 	pub face_count: u32,
 }
+
 #[derive(Debug, Clone)]
 pub struct Mesh1 {
 	pub header: Header1,
 	pub vertices: Vec<Vertex1>,
 }
 
-#[inline]
-pub fn fix_100(mesh: &mut Mesh1) {
+fn fix_100(mesh: &mut Mesh1) {
 	for vertex in &mut mesh.vertices {
 		for p in &mut vertex.pos {
 			*p = *p * 0.5;
 		}
 	}
 }
-#[inline]
-pub fn fix1(mesh: &mut Mesh1) {
+
+fn fix1(mesh: &mut Mesh1) {
 	for vertex in &mut mesh.vertices {
 		vertex.tex[1] = 1.0 - vertex.tex[1];
 	}
 }
-#[inline]
-pub fn check1(mesh: Mesh1) -> Result<Mesh1, Error1> {
+
+fn check1(mesh: Mesh1) -> Result<Mesh1, Error1> {
 	if 3 * (mesh.header.face_count as usize) == mesh.vertices.len() {
 		Ok(mesh)
 	} else {
@@ -79,20 +107,20 @@ pub fn check1(mesh: Mesh1) -> Result<Mesh1, Error1> {
 	}
 }
 
-#[inline]
-pub fn read_100<R: BufRead>(read: R) -> Result<Mesh1, Error1> {
-	let mut mesh = read1(read)?;
+fn read_100<R: BufRead>(revision: Revision1, read: R) -> Result<Mesh1, InnerError> {
+	let mut mesh = read1(revision, read)?;
 	//we'll fix it in post
 	fix1(&mut mesh);
 	fix_100(&mut mesh);
-	check1(mesh)
+	let mesh = check1(mesh)?;
+	Ok(mesh)
 }
 
-#[inline]
-pub fn read_101<R: BufRead>(read: R) -> Result<Mesh1, Error1> {
-	let mut mesh = read1(read)?;
+fn read_101<R: BufRead>(revision: Revision1, read: R) -> Result<Mesh1, InnerError> {
+	let mut mesh = read1(revision, read)?;
 	fix1(&mut mesh);
-	check1(mesh)
+	let mesh = check1(mesh)?;
+	Ok(mesh)
 }
 
 fn parse_triple_float(x: &str, y: &str, z: &str) -> Result<[f32; 3], std::num::ParseFloatError> {
@@ -108,18 +136,18 @@ macro_rules! lazy_regex {
 	}};
 }
 
-pub fn read1<R: BufRead>(read: R) -> Result<Mesh1, Error1> {
+fn read1<R: BufRead>(revision: Revision1, read: R) -> Result<Mesh1, InnerError> {
 	let mut lines = LineMachine::new(read);
-	let revision = match lines.read_line()?.trim() {
-		"version 1.00" => Revision1::Version100,
-		"version 1.01" => Revision1::Version101,
-		_ => return Err(Error1::Header),
-	};
+
+	// the first line contains the revision, but we already parsed it.
+	lines.read_line()?;
+
 	let face_count = lines
 		.read_line()?
 		.trim()
 		.parse()
 		.map_err(Error1::ParseIntError)?;
+
 	//final header
 	let header = Header1 {
 		revision,
@@ -144,4 +172,19 @@ pub fn read1<R: BufRead>(read: R) -> Result<Mesh1, Error1> {
 		.map_err(Error1::ParseFloatError)?;
 
 	Ok(Mesh1 { header, vertices })
+}
+
+impl binrw::BinRead for Mesh1 {
+	type Args<'a> = ();
+	fn read_options<R: BinReaderExt>(
+		reader: &mut R,
+		endian: binrw::Endian,
+		args: Self::Args<'_>,
+	) -> binrw::BinResult<Self> {
+		let revision = Revision1::read_options(reader, endian, args)?;
+		Ok(match revision {
+			Revision1::Version100 => read_100(revision, binrw::io::BufReader::new(reader))?,
+			Revision1::Version101 => read_101(revision, binrw::io::BufReader::new(reader))?,
+		})
+	}
 }

--- a/src/mesh/v1.rs
+++ b/src/mesh/v1.rs
@@ -98,44 +98,6 @@ macro_rules! lazy_regex {
 	}};
 }
 
-fn read1<R: BufRead>(revision: Revision1, read: R) -> Result<Mesh1, InnerError> {
-	let mut lines = LineMachine::new(read);
-
-	// the first line contains the revision, but we already parsed it.
-	lines.read_line()?;
-
-	let face_count = lines
-		.read_line()?
-		.trim()
-		.parse()
-		.map_err(Error1::ParseIntError)?;
-
-	//final header
-	let header = Header1 {
-		revision,
-		face_count,
-	};
-
-	let vertices_line = lines.read_line()?;
-	//match three at a time, otherwise fail
-	let vertex_pattern =
-		lazy_regex!(r"\[(.*?),(.*?),(.*?)\]\[(.*?),(.*?),(.*?)\]\[(.*?),(.*?),(.*?)\]");
-	let vertices = vertex_pattern
-		.captures_iter(vertices_line.as_str())
-		.map(|c| {
-			let (_, [px, py, pz, nx, ny, nz, tx, ty, tz]) = c.extract();
-			Ok(Vertex1 {
-				pos: parse_triple_float(px, py, pz)?,
-				norm: parse_triple_float(nx, ny, nz)?,
-				tex: parse_triple_float(tx, ty, tz)?,
-			})
-		})
-		.collect::<Result<Vec<Vertex1>, _>>()
-		.map_err(Error1::ParseFloatError)?;
-
-	Ok(Mesh1 { header, vertices })
-}
-
 impl binrw::BinRead for Mesh1 {
 	type Args<'a> = ();
 	fn read_options<R: BinReaderExt>(
@@ -145,7 +107,43 @@ impl binrw::BinRead for Mesh1 {
 	) -> binrw::BinResult<Self> {
 		let revision = Revision1::read_options(reader, endian, args)?;
 
-		let mut mesh = read1(revision, binrw::io::BufReader::new(reader))?;
+		let mut lines = LineMachine::new(binrw::io::BufReader::new(reader));
+
+		// the first line contains the revision, but we already parsed it.
+		lines.read_line()?;
+
+		let face_count = lines
+			.read_line()?
+			.trim()
+			.parse()
+			.map_err(|e| InnerError::Other(Error1::ParseIntError(e)))?;
+
+		//final header
+		let header = Header1 {
+			revision,
+			face_count,
+		};
+
+		let vertices_line = lines.read_line()?;
+
+		//match three at a time, otherwise fail
+		let vertex_pattern =
+			lazy_regex!(r"\[(.*?),(.*?),(.*?)\]\[(.*?),(.*?),(.*?)\]\[(.*?),(.*?),(.*?)\]");
+
+		let vertices = vertex_pattern
+			.captures_iter(vertices_line.as_str())
+			.map(|c| {
+				let (_, [px, py, pz, nx, ny, nz, tx, ty, tz]) = c.extract();
+				Ok(Vertex1 {
+					pos: parse_triple_float(px, py, pz)?,
+					norm: parse_triple_float(nx, ny, nz)?,
+					tex: parse_triple_float(tx, ty, tz)?,
+				})
+			})
+			.collect::<Result<Vec<Vertex1>, _>>()
+			.map_err(|e| InnerError::Other(Error1::ParseFloatError(e)))?;
+
+		let mut mesh = Mesh1 { header, vertices };
 
 		// fix texture coordinates
 		for vertex in &mut mesh.vertices {

--- a/src/mesh/v1.rs
+++ b/src/mesh/v1.rs
@@ -85,44 +85,6 @@ pub struct Mesh1 {
 	pub vertices: Vec<Vertex1>,
 }
 
-fn fix_100(mesh: &mut Mesh1) {
-	for vertex in &mut mesh.vertices {
-		for p in &mut vertex.pos {
-			*p = *p * 0.5;
-		}
-	}
-}
-
-fn fix1(mesh: &mut Mesh1) {
-	for vertex in &mut mesh.vertices {
-		vertex.tex[1] = 1.0 - vertex.tex[1];
-	}
-}
-
-fn check1(mesh: Mesh1) -> Result<Mesh1, Error1> {
-	if 3 * (mesh.header.face_count as usize) == mesh.vertices.len() {
-		Ok(mesh)
-	} else {
-		Err(Error1::VertexCount)
-	}
-}
-
-fn read_100<R: BufRead>(revision: Revision1, read: R) -> Result<Mesh1, InnerError> {
-	let mut mesh = read1(revision, read)?;
-	//we'll fix it in post
-	fix1(&mut mesh);
-	fix_100(&mut mesh);
-	let mesh = check1(mesh)?;
-	Ok(mesh)
-}
-
-fn read_101<R: BufRead>(revision: Revision1, read: R) -> Result<Mesh1, InnerError> {
-	let mut mesh = read1(revision, read)?;
-	fix1(&mut mesh);
-	let mesh = check1(mesh)?;
-	Ok(mesh)
-}
-
 fn parse_triple_float(x: &str, y: &str, z: &str) -> Result<[f32; 3], std::num::ParseFloatError> {
 	Ok([x.trim().parse()?, y.trim().parse()?, z.trim().parse()?])
 }
@@ -182,9 +144,28 @@ impl binrw::BinRead for Mesh1 {
 		args: Self::Args<'_>,
 	) -> binrw::BinResult<Self> {
 		let revision = Revision1::read_options(reader, endian, args)?;
-		Ok(match revision {
-			Revision1::Version100 => read_100(revision, binrw::io::BufReader::new(reader))?,
-			Revision1::Version101 => read_101(revision, binrw::io::BufReader::new(reader))?,
-		})
+
+		let mut mesh = read1(revision, binrw::io::BufReader::new(reader))?;
+
+		// fix texture coordinates
+		for vertex in &mut mesh.vertices {
+			vertex.tex[1] = 1.0 - vertex.tex[1];
+		}
+
+		// mesh v1.00 is double size for some reason
+		if let Revision1::Version100 = &mesh.header.revision {
+			for vertex in &mut mesh.vertices {
+				for p in &mut vertex.pos {
+					*p = *p * 0.5;
+				}
+			}
+		}
+
+		// assert vertex count matches header
+		if 3 * (mesh.header.face_count as usize) != mesh.vertices.len() {
+			return Err(InnerError::Other(Error1::VertexCount).into());
+		}
+
+		Ok(mesh)
 	}
 }

--- a/src/mesh/v2.rs
+++ b/src/mesh/v2.rs
@@ -1,7 +1,3 @@
-use binrw::BinReaderExt;
-
-pub const DEFAULT_VERTEX_TANGENT: [i8; 4] = [0, 0, -128, 127];
-
 #[binrw::binrw]
 #[brw(little)]
 #[derive(Debug, Clone)]
@@ -77,25 +73,4 @@ pub struct Mesh2 {
 	pub vertices_truncated: Vec<Vertex2Truncated>,
 	#[br(count=header.face_count)]
 	pub faces: Vec<Face2>,
-}
-
-#[inline]
-pub fn fix2(mesh: &mut Mesh2) {
-	for vertex in &mut mesh.vertices {
-		match vertex.tangent {
-			[-128, -128, -128, -128] => vertex.tangent = DEFAULT_VERTEX_TANGENT,
-			_ => (),
-		}
-	}
-}
-
-#[inline]
-pub fn read_200<R: BinReaderExt>(read: R) -> Result<Mesh2, binrw::Error> {
-	let mut mesh = read2(read)?;
-	fix2(&mut mesh);
-	Ok(mesh)
-}
-
-pub fn read2<R: BinReaderExt>(mut read: R) -> Result<Mesh2, binrw::Error> {
-	read.read_le()
 }

--- a/src/mesh/v2.rs
+++ b/src/mesh/v2.rs
@@ -1,14 +1,12 @@
 use binrw::BinReaderExt;
 
-use std::io::{Read, Seek};
-
 use super::DEFAULT_VERTEX_TANGENT;
 
 #[binrw::binrw]
 #[brw(little)]
 #[derive(Debug, Clone)]
 pub enum Revision2 {
-	#[brw(magic = b"2.00")]
+	#[brw(magic = b"version 2.00")]
 	Version200,
 }
 
@@ -26,7 +24,6 @@ pub enum SizeOfVertex2 {
 #[brw(little)]
 #[derive(Debug, Clone)]
 pub struct Header2 {
-	#[brw(magic = b"version ")]
 	pub revision: Revision2,
 	#[brw(magic = b"\n\x0C\0")] //newline,sizeof_header
 	//sizeof_header:u16,//12=0x000C
@@ -93,7 +90,7 @@ pub fn fix2(mesh: &mut Mesh2) {
 }
 
 #[inline]
-pub fn read_200<R: Read + Seek>(read: R) -> Result<Mesh2, binrw::Error> {
+pub fn read_200<R: BinReaderExt>(read: R) -> Result<Mesh2, binrw::Error> {
 	let mut mesh = read2(read)?;
 	fix2(&mut mesh);
 	Ok(mesh)

--- a/src/mesh/v2.rs
+++ b/src/mesh/v2.rs
@@ -1,6 +1,6 @@
 use binrw::BinReaderExt;
 
-use super::DEFAULT_VERTEX_TANGENT;
+pub const DEFAULT_VERTEX_TANGENT: [i8; 4] = [0, 0, -128, 127];
 
 #[binrw::binrw]
 #[brw(little)]

--- a/src/mesh/v3.rs
+++ b/src/mesh/v3.rs
@@ -1,7 +1,5 @@
 use binrw::BinReaderExt;
 
-use std::io::{Read, Seek};
-
 use super::v2::{Face2, SizeOfVertex2, Vertex2, Vertex2Truncated};
 use super::DEFAULT_VERTEX_TANGENT;
 
@@ -9,9 +7,9 @@ use super::DEFAULT_VERTEX_TANGENT;
 #[brw(little)]
 #[derive(Debug, Clone)]
 pub enum Revision3 {
-	#[brw(magic = b"3.00")]
+	#[brw(magic = b"version 3.00")]
 	Version300,
-	#[brw(magic = b"3.01")]
+	#[brw(magic = b"version 3.01")]
 	Version301,
 }
 
@@ -19,7 +17,6 @@ pub enum Revision3 {
 #[brw(little)]
 #[derive(Debug, Clone)]
 pub struct Header3 {
-	#[brw(magic = b"version ")]
 	pub revision: Revision3,
 	#[brw(magic = b"\n\x10\0")] //newline,sizeof_header
 	//sizeof_header:u16,//16=0x0010
@@ -67,7 +64,7 @@ pub fn fix3(mesh: &mut Mesh3) {
 }
 
 #[inline]
-pub fn read_300<R: Read + Seek>(read: R) -> Result<Mesh3, binrw::Error> {
+pub fn read_300<R: BinReaderExt>(read: R) -> Result<Mesh3, binrw::Error> {
 	let mut mesh = read3(read)?;
 	fix3(&mut mesh);
 	Ok(mesh)

--- a/src/mesh/v3.rs
+++ b/src/mesh/v3.rs
@@ -1,7 +1,7 @@
 use binrw::BinReaderExt;
 
+use super::v2::DEFAULT_VERTEX_TANGENT;
 use super::v2::{Face2, SizeOfVertex2, Vertex2, Vertex2Truncated};
-use super::DEFAULT_VERTEX_TANGENT;
 
 #[binrw::binrw]
 #[brw(little)]

--- a/src/mesh/v3.rs
+++ b/src/mesh/v3.rs
@@ -1,6 +1,3 @@
-use binrw::BinReaderExt;
-
-use super::v2::DEFAULT_VERTEX_TANGENT;
 use super::v2::{Face2, SizeOfVertex2, Vertex2, Vertex2Truncated};
 
 #[binrw::binrw]
@@ -51,25 +48,4 @@ pub struct Mesh3 {
 	pub faces: Vec<Face2>,
 	#[br(count=header.lod_count)]
 	pub lods: Vec<Lod3>,
-}
-
-#[inline]
-pub fn fix3(mesh: &mut Mesh3) {
-	for vertex in &mut mesh.vertices {
-		match vertex.tangent {
-			[-128, -128, -128, -128] => vertex.tangent = DEFAULT_VERTEX_TANGENT,
-			_ => (),
-		}
-	}
-}
-
-#[inline]
-pub fn read_300<R: BinReaderExt>(read: R) -> Result<Mesh3, binrw::Error> {
-	let mut mesh = read3(read)?;
-	fix3(&mut mesh);
-	Ok(mesh)
-}
-
-pub fn read3<R: BinReaderExt>(mut read: R) -> Result<Mesh3, binrw::Error> {
-	read.read_le()
 }

--- a/src/mesh/v4.rs
+++ b/src/mesh/v4.rs
@@ -1,7 +1,5 @@
 use binrw::BinReaderExt;
 
-use std::io::{Read, Seek};
-
 use super::v2::{Face2, Vertex2};
 use super::v3::Lod3;
 use super::DEFAULT_VERTEX_TANGENT;
@@ -10,9 +8,9 @@ use super::DEFAULT_VERTEX_TANGENT;
 #[brw(little)]
 #[derive(Debug, Clone)]
 pub enum Revision4 {
-	#[brw(magic = b"4.00")]
+	#[brw(magic = b"version 4.00")]
 	Version400,
-	#[brw(magic = b"4.01")]
+	#[brw(magic = b"version 4.01")]
 	Version401,
 }
 
@@ -31,7 +29,6 @@ pub enum LodType4 {
 #[brw(little)]
 #[derive(Debug, Clone)]
 pub struct Header4 {
-	#[brw(magic = b"version ")]
 	pub revision: Revision4,
 	#[brw(magic = b"\n\x18\0")] //newline,sizeof_header
 	//sizeof_header:u16,//24
@@ -148,7 +145,7 @@ pub fn fix4(mesh: &mut Mesh4) {
 }
 
 #[inline]
-pub fn read_400<R: Read + Seek>(read: R) -> Result<Mesh4, binrw::Error> {
+pub fn read_400<R: BinReaderExt>(read: R) -> Result<Mesh4, binrw::Error> {
 	let mut mesh = read4(read)?;
 	fix4(&mut mesh);
 	Ok(mesh)

--- a/src/mesh/v4.rs
+++ b/src/mesh/v4.rs
@@ -1,8 +1,8 @@
 use binrw::BinReaderExt;
 
+use super::v2::DEFAULT_VERTEX_TANGENT;
 use super::v2::{Face2, Vertex2};
 use super::v3::Lod3;
-use super::DEFAULT_VERTEX_TANGENT;
 
 #[binrw::binrw]
 #[brw(little)]

--- a/src/mesh/v4.rs
+++ b/src/mesh/v4.rs
@@ -1,6 +1,3 @@
-use binrw::BinReaderExt;
-
-use super::v2::DEFAULT_VERTEX_TANGENT;
 use super::v2::{Face2, Vertex2};
 use super::v3::Lod3;
 
@@ -132,25 +129,4 @@ pub struct Mesh4 {
 	pub bone_names: Vec<u8>,
 	#[br(count=header.subset_count)]
 	pub subsets: Vec<Subset4>,
-}
-
-#[inline]
-pub fn fix4(mesh: &mut Mesh4) {
-	for vertex in &mut mesh.vertices {
-		match vertex.tangent {
-			[-128, -128, -128, -128] => vertex.tangent = DEFAULT_VERTEX_TANGENT,
-			_ => (),
-		}
-	}
-}
-
-#[inline]
-pub fn read_400<R: BinReaderExt>(read: R) -> Result<Mesh4, binrw::Error> {
-	let mut mesh = read4(read)?;
-	fix4(&mut mesh);
-	Ok(mesh)
-}
-
-pub fn read4<R: BinReaderExt>(mut read: R) -> Result<Mesh4, binrw::Error> {
-	read.read_le()
 }

--- a/src/mesh/v5.rs
+++ b/src/mesh/v5.rs
@@ -1,7 +1,5 @@
 use binrw::BinReaderExt;
 
-use std::io::{Read, Seek};
-
 use super::v2::{Face2, Vertex2};
 use super::v3::Lod3;
 use super::v4::{Bone4, Envelope4, LodType4, Subset4};
@@ -11,7 +9,7 @@ use super::DEFAULT_VERTEX_TANGENT;
 #[brw(little)]
 #[derive(Debug, Clone)]
 pub enum Revision5 {
-	#[brw(magic = b"5.00")]
+	#[brw(magic = b"version 5.00")]
 	Version500,
 }
 
@@ -26,7 +24,6 @@ pub enum FacsFormat5 {
 #[brw(little)]
 #[derive(Debug, Clone)]
 pub struct Header5 {
-	#[brw(magic = b"version ")]
 	pub revision: Revision5,
 	#[brw(magic = b"\n\x20\0")] //newline,sizeof_header
 	//sizeof_header:u16,//32=0x0020
@@ -148,7 +145,7 @@ pub fn fix5(mesh: &mut Mesh5) {
 }
 
 #[inline]
-pub fn read_500<R: Read + Seek>(read: R) -> Result<Mesh5, binrw::Error> {
+pub fn read_500<R: BinReaderExt>(read: R) -> Result<Mesh5, binrw::Error> {
 	let mut mesh = read5(read)?;
 	fix5(&mut mesh);
 	Ok(mesh)

--- a/src/mesh/v5.rs
+++ b/src/mesh/v5.rs
@@ -1,6 +1,3 @@
-use binrw::BinReaderExt;
-
-use super::v2::DEFAULT_VERTEX_TANGENT;
 use super::v2::{Face2, Vertex2};
 use super::v3::Lod3;
 use super::v4::{Bone4, Envelope4, LodType4, Subset4};
@@ -132,25 +129,4 @@ pub struct Mesh5 {
 	#[br(count=header.subset_count)]
 	pub subsets: Vec<Subset4>,
 	pub facs: Facs5,
-}
-
-#[inline]
-pub fn fix5(mesh: &mut Mesh5) {
-	for vertex in &mut mesh.vertices {
-		match vertex.tangent {
-			[-128, -128, -128, -128] => vertex.tangent = DEFAULT_VERTEX_TANGENT,
-			_ => (),
-		}
-	}
-}
-
-#[inline]
-pub fn read_500<R: BinReaderExt>(read: R) -> Result<Mesh5, binrw::Error> {
-	let mut mesh = read5(read)?;
-	fix5(&mut mesh);
-	Ok(mesh)
-}
-
-pub fn read5<R: BinReaderExt>(mut read: R) -> Result<Mesh5, binrw::Error> {
-	read.read_le()
 }

--- a/src/mesh/v5.rs
+++ b/src/mesh/v5.rs
@@ -1,9 +1,9 @@
 use binrw::BinReaderExt;
 
+use super::v2::DEFAULT_VERTEX_TANGENT;
 use super::v2::{Face2, Vertex2};
 use super::v3::Lod3;
 use super::v4::{Bone4, Envelope4, LodType4, Subset4};
-use super::DEFAULT_VERTEX_TANGENT;
 
 #[binrw::binrw]
 #[brw(little)]

--- a/src/test/mesh.rs
+++ b/src/test/mesh.rs
@@ -1,5 +1,4 @@
 use binrw::{BinReaderExt, BinWrite};
-use std::io::Read;
 
 use crate::mesh::*;
 fn load_mesh(name: &str) -> Result<Mesh, Error> {
@@ -30,44 +29,35 @@ fn get_mesh_id(mesh: Mesh) -> u16 {
 }
 //Mesh1 has no round trip since there is no writer
 fn round_trip2(name: &str) {
-	let mut file = std::fs::File::open(name).unwrap();
-	let mut rbuf = Vec::new();
-	let mut wbuf = Vec::new();
-	file.read_to_end(&mut rbuf).unwrap();
+	let mut rbuf = binrw::io::Cursor::new(std::fs::read(name).unwrap());
+	let mut wbuf = binrw::io::Cursor::new(Vec::new());
 	//read and then write mesh
-	let mesh: Mesh2 = binrw::io::Cursor::new(&rbuf).read_le().unwrap();
-	mesh.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
-		.unwrap();
+	let mesh: Mesh2 = rbuf.read_le().unwrap();
+	mesh.write_le(&mut wbuf).unwrap();
 	assert_eq!(rbuf, wbuf);
 }
 fn round_trip3(name: &str) {
-	let mut file = std::fs::File::open(name).unwrap();
-	let mut rbuf = Vec::new();
-	let mut wbuf = Vec::new();
-	file.read_to_end(&mut rbuf).unwrap();
-	let mesh: Mesh3 = binrw::io::Cursor::new(&rbuf).read_le().unwrap();
-	mesh.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
-		.unwrap();
+	let mut rbuf = binrw::io::Cursor::new(std::fs::read(name).unwrap());
+	let mut wbuf = binrw::io::Cursor::new(Vec::new());
+	//read and then write mesh
+	let mesh: Mesh3 = rbuf.read_le().unwrap();
+	mesh.write_le(&mut wbuf).unwrap();
 	assert_eq!(rbuf, wbuf);
 }
 fn round_trip4(name: &str) {
-	let mut file = std::fs::File::open(name).unwrap();
-	let mut rbuf = Vec::new();
-	let mut wbuf = Vec::new();
-	file.read_to_end(&mut rbuf).unwrap();
-	let mesh: Mesh4 = binrw::io::Cursor::new(&rbuf).read_le().unwrap();
-	mesh.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
-		.unwrap();
+	let mut rbuf = binrw::io::Cursor::new(std::fs::read(name).unwrap());
+	let mut wbuf = binrw::io::Cursor::new(Vec::new());
+	//read and then write mesh
+	let mesh: Mesh4 = rbuf.read_le().unwrap();
+	mesh.write_le(&mut wbuf).unwrap();
 	assert_eq!(rbuf, wbuf);
 }
 fn round_trip5(name: &str) {
-	let mut file = std::fs::File::open(name).unwrap();
-	let mut rbuf = Vec::new();
-	let mut wbuf = Vec::new();
-	file.read_to_end(&mut rbuf).unwrap();
-	let mesh: Mesh5 = binrw::io::Cursor::new(&rbuf).read_le().unwrap();
-	mesh.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
-		.unwrap();
+	let mut rbuf = binrw::io::Cursor::new(std::fs::read(name).unwrap());
+	let mut wbuf = binrw::io::Cursor::new(Vec::new());
+	//read and then write mesh
+	let mesh: Mesh5 = rbuf.read_le().unwrap();
+	mesh.write_le(&mut wbuf).unwrap();
 	assert_eq!(rbuf, wbuf);
 }
 

--- a/src/test/mesh.rs
+++ b/src/test/mesh.rs
@@ -1,4 +1,4 @@
-use binrw::BinWrite;
+use binrw::{BinReaderExt, BinWrite};
 use std::io::Read;
 
 use crate::mesh::*;
@@ -35,9 +35,8 @@ fn round_trip2(name: &str) {
 	let mut wbuf = Vec::new();
 	file.read_to_end(&mut rbuf).unwrap();
 	//read and then write mesh
-	read2(binrw::io::Cursor::new(&rbuf))
-		.unwrap()
-		.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
+	let mesh: Mesh2 = binrw::io::Cursor::new(&rbuf).read_le().unwrap();
+	mesh.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
 		.unwrap();
 	assert_eq!(rbuf, wbuf);
 }
@@ -46,9 +45,8 @@ fn round_trip3(name: &str) {
 	let mut rbuf = Vec::new();
 	let mut wbuf = Vec::new();
 	file.read_to_end(&mut rbuf).unwrap();
-	read3(binrw::io::Cursor::new(&rbuf))
-		.unwrap()
-		.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
+	let mesh: Mesh3 = binrw::io::Cursor::new(&rbuf).read_le().unwrap();
+	mesh.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
 		.unwrap();
 	assert_eq!(rbuf, wbuf);
 }
@@ -57,9 +55,8 @@ fn round_trip4(name: &str) {
 	let mut rbuf = Vec::new();
 	let mut wbuf = Vec::new();
 	file.read_to_end(&mut rbuf).unwrap();
-	read4(binrw::io::Cursor::new(&rbuf))
-		.unwrap()
-		.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
+	let mesh: Mesh4 = binrw::io::Cursor::new(&rbuf).read_le().unwrap();
+	mesh.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
 		.unwrap();
 	assert_eq!(rbuf, wbuf);
 }
@@ -68,9 +65,8 @@ fn round_trip5(name: &str) {
 	let mut rbuf = Vec::new();
 	let mut wbuf = Vec::new();
 	file.read_to_end(&mut rbuf).unwrap();
-	read5(binrw::io::Cursor::new(&rbuf))
-		.unwrap()
-		.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
+	let mesh: Mesh5 = binrw::io::Cursor::new(&rbuf).read_le().unwrap();
+	mesh.write_le(&mut binrw::io::Cursor::new(&mut wbuf))
 		.unwrap();
 	assert_eq!(rbuf, wbuf);
 }

--- a/src/test/mesh.rs
+++ b/src/test/mesh.rs
@@ -1,4 +1,4 @@
-use binrw::{BinReaderExt, BinWrite};
+use binrw::BinWriterExt;
 
 use crate::mesh::*;
 fn load_mesh(name: &str) -> Result<Mesh, Error> {
@@ -28,36 +28,18 @@ fn get_mesh_id(mesh: Mesh) -> u16 {
 	}
 }
 //Mesh1 has no round trip since there is no writer
-fn round_trip2(name: &str) {
+fn round_trip(name: &str) {
 	let mut rbuf = binrw::io::Cursor::new(std::fs::read(name).unwrap());
 	let mut wbuf = binrw::io::Cursor::new(Vec::new());
 	//read and then write mesh
-	let mesh: Mesh2 = rbuf.read_le().unwrap();
-	mesh.write_le(&mut wbuf).unwrap();
-	assert_eq!(rbuf, wbuf);
-}
-fn round_trip3(name: &str) {
-	let mut rbuf = binrw::io::Cursor::new(std::fs::read(name).unwrap());
-	let mut wbuf = binrw::io::Cursor::new(Vec::new());
-	//read and then write mesh
-	let mesh: Mesh3 = rbuf.read_le().unwrap();
-	mesh.write_le(&mut wbuf).unwrap();
-	assert_eq!(rbuf, wbuf);
-}
-fn round_trip4(name: &str) {
-	let mut rbuf = binrw::io::Cursor::new(std::fs::read(name).unwrap());
-	let mut wbuf = binrw::io::Cursor::new(Vec::new());
-	//read and then write mesh
-	let mesh: Mesh4 = rbuf.read_le().unwrap();
-	mesh.write_le(&mut wbuf).unwrap();
-	assert_eq!(rbuf, wbuf);
-}
-fn round_trip5(name: &str) {
-	let mut rbuf = binrw::io::Cursor::new(std::fs::read(name).unwrap());
-	let mut wbuf = binrw::io::Cursor::new(Vec::new());
-	//read and then write mesh
-	let mesh: Mesh5 = rbuf.read_le().unwrap();
-	mesh.write_le(&mut wbuf).unwrap();
+	let mesh: Mesh = read_versioned(&mut rbuf).unwrap();
+	match mesh {
+		Mesh::V1(_mesh) => panic!("Cannot round trip Mesh v1"),
+		Mesh::V2(mesh) => wbuf.write_le(&mesh).unwrap(),
+		Mesh::V3(mesh) => wbuf.write_le(&mesh).unwrap(),
+		Mesh::V4(mesh) => wbuf.write_le(&mesh).unwrap(),
+		Mesh::V5(mesh) => wbuf.write_le(&mesh).unwrap(),
+	}
 	assert_eq!(rbuf, wbuf);
 }
 
@@ -72,7 +54,7 @@ fn mesh_200() {
 }
 #[test]
 fn roundtrip_200() {
-	round_trip2("meshes/torso.mesh");
+	round_trip("meshes/torso.mesh");
 }
 #[test]
 fn mesh_300() {
@@ -80,7 +62,7 @@ fn mesh_300() {
 }
 #[test]
 fn roundtrip_300() {
-	round_trip3("meshes/5115672913");
+	round_trip("meshes/5115672913");
 }
 #[test]
 fn mesh_301() {
@@ -88,7 +70,7 @@ fn mesh_301() {
 }
 #[test]
 fn roundtrip_301() {
-	round_trip3("meshes/5648093777");
+	round_trip("meshes/5648093777");
 }
 #[test]
 fn mesh_401() {
@@ -96,7 +78,7 @@ fn mesh_401() {
 }
 #[test]
 fn roundtrip_401() {
-	round_trip4("meshes/sphere.mesh");
+	round_trip("meshes/sphere.mesh");
 }
 #[test]
 fn mesh_401_random_padding() {
@@ -104,7 +86,7 @@ fn mesh_401_random_padding() {
 }
 #[test]
 fn roundtrip_401_random_padding() {
-	round_trip4("meshes/7665777615");
+	round_trip("meshes/7665777615");
 }
 //the only three v5.00 meshes I could find in bhop and surf
 #[test]
@@ -113,7 +95,7 @@ fn mesh_500() {
 }
 #[test]
 fn roundtrip_500() {
-	round_trip5("meshes/13674780763");
+	round_trip("meshes/13674780763");
 }
 #[test]
 fn mesh_500_alt1() {
@@ -121,7 +103,7 @@ fn mesh_500_alt1() {
 }
 #[test]
 fn roundtrip_500_alt1() {
-	round_trip5("meshes/14818281896");
+	round_trip("meshes/14818281896");
 }
 #[test]
 fn mesh_500_alt2() {
@@ -129,6 +111,6 @@ fn mesh_500_alt2() {
 }
 #[test]
 fn roundtrip_500_alt2() {
-	round_trip5("meshes/15256456161");
+	round_trip("meshes/15256456161");
 }
 //also tested against ~2500 meshes from bhop and surf maps


### PR DESCRIPTION
Unify Mesh1 with the other mesh variants, eliminating the header seek code.  Also remove some other kludge.

I don't like how `fix_vertex2_tangents` can be bypassed by directly using the binrw trait `let mesh: Mesh2 = reader.read_le()?;`, resulting in an invalid mesh.

Turns out missing tangents don't appear in my dataset, I'm just going to hand off the problem to library consumers instead of running useless code every time a mesh is decoded.