### PR TITLE
fix: CSGPHS8 bitreader reading multiple bits on edge of word

### DIFF
--- a/src/union_physics/v8/roblox_bit_reader.rs
+++ b/src/union_physics/v8/roblox_bit_reader.rs
@@ -50,7 +50,7 @@ impl<'a> RobloxBitReader<'a> {
 		if self.cache.bits() < bits {
 			
 			// populate value with remaining bits of cache
-			let pre_read_bits = self.cache_bits();
+			let pre_read_bits = self.cache.bits();
 			value.push_lsb(pre_read_bits, self.cache.pop_msb(pre_read_bits));
 			
 			// bits are lsb-aligned

--- a/src/union_physics/v8/roblox_bit_reader.rs
+++ b/src/union_physics/v8/roblox_bit_reader.rs
@@ -44,22 +44,28 @@ impl<'a> RobloxBitReader<'a> {
 	}
 	pub fn read(&mut self, bits: u32) -> Result<Cache, BitCounterError> {
 		debug_assert!(bits <= Cache::BITS);
+		let mut value = BitBuffer::empty();
 
 		// replace cache if we need more bits
-		let mut value = if self.cache.bits() < bits {
-			let draw_bits = self.bit_count.min(BitBuffer::CAPACITY);
+		if self.cache.bits() < bits {
+			
+			// populate value with remaining bits of cache
+			let pre_read_bits = self.cache_bits();
+			value.push_lsb(pre_read_bits, self.cache.pop_msb(pre_read_bits));
+			
+			// bits are lsb-aligned
+			let draw_bits = BitBuffer::CAPACITY.min(self.bit_count);
 			self.bit_count -= draw_bits;
+			
+			let new_cache = BitBuffer::new(
+				self.chunks.next().copied().map_or(0, Cache::from_le_bytes),
+				draw_bits,
+			);
 			core::mem::replace(
 				&mut self.cache,
-				BitBuffer::new(
-					self.chunks.next().copied().map_or(0, Cache::from_le_bytes),
-					// bits are lsb-aligned
-					draw_bits,
-				),
-			)
-		} else {
-			BitBuffer::empty()
-		};
+				new_cache,
+			);
+		}
 
 		let draw_bits = bits - value.bits();
 		if self.cache.bits() < draw_bits {

--- a/src/union_physics/v8/roblox_bit_reader.rs
+++ b/src/union_physics/v8/roblox_bit_reader.rs
@@ -57,13 +57,9 @@ impl<'a> RobloxBitReader<'a> {
 			let draw_bits = BitBuffer::CAPACITY.min(self.bit_count);
 			self.bit_count -= draw_bits;
 			
-			let new_cache = BitBuffer::new(
+			self.cache = BitBuffer::new(
 				self.chunks.next().copied().map_or(0, Cache::from_le_bytes),
 				draw_bits,
-			);
-			core::mem::replace(
-				&mut self.cache,
-				new_cache,
 			);
 		}
 


### PR DESCRIPTION
No loss of functionality reported:

```
running 27 tests
test test::union_graphics::meshdata_13626979828_5 ... FAILED
test test::union_physics::csgk ... ok
test test::mesh::mesh_200 ... ok
test test::union_graphics::meshdata_5692112940_2 ... ok
test test::union_graphics::meshdata_385416572_2 ... ok
test test::union_graphics::meshdata_14846974687_5 ... ok
test test::union_physics::csgphs_3 ... ok
test test::union_physics::csgphs_5 ... ok
test union_physics::v8::bit_buffer::test_fifo_lsb ... ok
test union_physics::v8::clers_symbol::empirical ... ok
test union_physics::v8::clers_symbol::read_symbols ... ok
test test::union_physics::csgphs_7 ... ok
test test::union_physics::csgphs_8_raw_hull_2 ... ok
test test::union_graphics::meshdata_15124417947_5 ... ok
test union_physics::v8::edgebreaker::test_edge_id ... ok
test test::union_physics::csgphs_8_raw_hull_1 ... ok
test test::union_physics::csgphs_8 ... ok
test test::union_graphics::meshdata_4500696697_4 ... ok
test test::mesh::mesh_300 ... ok
test test::union_graphics::meshdata_394453730_2 ... ok
test test::mesh::mesh_500_alt2 ... ok
test test::mesh::mesh_401_random_padding ... ok
test test::mesh::mesh_500_alt1 ... ok
test test::mesh::mesh_500 ... ok
test test::mesh::mesh_301 ... ok
test test::mesh::mesh_401 ... ok
test test::mesh::mesh_100 ... ok

failures:

---- test::union_graphics::meshdata_13626979828_5 stdout ----

thread 'test::union_graphics::meshdata_13626979828_5' (11) panicked at src/union_graphics/v5.rs:92:21:
attempt to add with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```