### PR TITLE
build: require compiler 1.94

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "rbx_mesh"
+rust-version = "1.94"
 version = "0.7.0"
 edition = "2024"
 repository = "https://github.com/krakow10/rbx_mesh"


### PR DESCRIPTION
Attempting to compile on older versions will yield:

```
error[E0658]: use of unstable library feature `array_windows`
  --> src\union_physics\v8\raw_hulls.rs:25:25
   |
25 |             .zip(self.pos_ranges.array_windows())
   |                                  ^^^^^^^^^^^^^
   |
   = note: see issue #75027 <https://github.com/rust-lang/rust/issues/75027> for more information
```

https://alternativeto.net/news/2026/3/rust-1-94-introduces-array-windows-cargo-config-inclusion-annd-toml-1-1-support-in-cargo/